### PR TITLE
Fix deprecated ESPBTUUID::to_string() → to_str()

### DIFF
--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -63,7 +63,7 @@ void VotronicBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
           this->parent_->get_characteristic(this->service_monitoring_uuid_, this->char_battery_computer_uuid_);
       if (char_battery_computer == nullptr) {
         ESP_LOGW(TAG, "[%s] No battery computer characteristic found at device. No battery computer attached?",
-                 ADDR_STR(this->parent_->address_str()));
+                 this->parent_->address_str());
         break;
       }
       this->char_battery_computer_handle_ = char_battery_computer->handle;
@@ -78,7 +78,7 @@ void VotronicBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
           this->parent_->get_characteristic(this->service_monitoring_uuid_, this->char_solar_charger_uuid_);
       if (char_solar_charger == nullptr) {
         ESP_LOGW(TAG, "[%s] No solar charger characteristic found at device. No solar charger attached?",
-                 ADDR_STR(this->parent_->address_str()));
+                 this->parent_->address_str());
         break;
       }
       this->char_solar_charger_handle_ = char_solar_charger->handle;
@@ -111,7 +111,7 @@ void VotronicBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
 
 void VotronicBle::update() {
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
+    ESP_LOGW(TAG, "[%s] Not connected", this->parent_->address_str());
     return;
   }
 }

--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -1,13 +1,7 @@
 #include "votronic_ble.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include "esphome/core/version.h"
 
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 12, 0)
-#define ADDR_STR(x) x
-#else
-#define ADDR_STR(x) (x).c_str()
-#endif
 
 namespace esphome {
 namespace votronic_ble {
@@ -229,11 +223,16 @@ void VotronicBle::decode_solar_charger_data_(const std::vector<uint8_t> &data) {
 
 void VotronicBle::dump_config() {
   ESP_LOGCONFIG(TAG, "VotronicBle:");
-  ESP_LOGCONFIG(TAG, "  MAC address                         : %s", ADDR_STR(this->parent_->address_str()));
-  ESP_LOGCONFIG(TAG, "  Monitoring Service UUID             : %s", this->service_monitoring_uuid_.to_string().c_str());
+  ESP_LOGCONFIG(TAG, "  MAC address                         : %s", this->parent_->address_str());
+  char service_monitoring_uuid_str[esp32_ble::UUID_STR_LEN];
+  char char_battery_computer_uuid_str[esp32_ble::UUID_STR_LEN];
+  char char_solar_charger_uuid_str[esp32_ble::UUID_STR_LEN];
+  ESP_LOGCONFIG(TAG, "  Monitoring Service UUID             : %s",
+                this->service_monitoring_uuid_.to_str(service_monitoring_uuid_str));
   ESP_LOGCONFIG(TAG, "  Battery Computer Characteristic UUID: %s",
-                this->char_battery_computer_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Solar Charger Characteristic UUID   : %s", this->char_solar_charger_uuid_.to_string().c_str());
+                this->char_battery_computer_uuid_.to_str(char_battery_computer_uuid_str));
+  ESP_LOGCONFIG(TAG, "  Solar Charger Characteristic UUID   : %s",
+                this->char_solar_charger_uuid_.to_str(char_solar_charger_uuid_str));
 
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);

--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -2,7 +2,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-
 namespace esphome {
 namespace votronic_ble {
 

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.1.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.1.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0
@@ -42,7 +42,8 @@ esp32_ble_tracker:
             ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
             for (auto uuid : x.get_service_uuids()) {
-              ESP_LOGD("ble_adv", "    - %s", uuid.to_string().c_str());
+              char buf[ESPBTUUID::UUID_STR_LEN];
+              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(buf));
             }
           }
 

--- a/esp8266-charger-example.yaml
+++ b/esp8266-charger-example.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-charging-converter-example.yaml
+++ b/esp8266-charging-converter-example.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-smart-shunt-example.yaml
+++ b/esp8266-smart-shunt-example.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-solar-charger-example.yaml
+++ b/esp8266-solar-charger-example.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-triple-charger-example.yaml
+++ b/esp8266-triple-charger-example.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -9,7 +9,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
+  min_version: 2026.2.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-fake-charger-vbcs-triple.yaml
+++ b/tests/esp8266-fake-charger-vbcs-triple.yaml
@@ -10,7 +10,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-charger.yaml
+++ b/tests/esp8266-fake-charger.yaml
@@ -7,7 +7,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-charging-converter.yaml
+++ b/tests/esp8266-fake-charging-converter.yaml
@@ -7,7 +7,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-solar-charger.yaml
+++ b/tests/esp8266-fake-solar-charger.yaml
@@ -7,7 +7,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0


### PR DESCRIPTION
Replace uuid.to_string().c_str() with stack-based uuid.to_str(buf) and bump min_version to 2026.1.0 (to_str() added in ESPHome 2026.1.0, to_string() removed in 2026.8.0).