### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/votronic/__init__.py
+++ b/components/votronic/__init__.py
@@ -21,7 +21,8 @@ VOTRONIC_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Votronic),
@@ -34,7 +35,7 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.polling_component_schema("never"))
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/votronic_ble/__init__.py
+++ b/components/votronic_ble/__init__.py
@@ -14,7 +14,8 @@ VotronicBle = votronic_ble_ns.class_(
     "VotronicBle", ble_client.BLEClientNode, cg.PollingComponent
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2026, 1, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(VotronicBle),
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
-    .extend(cv.polling_component_schema("2s"))
+    .extend(cv.polling_component_schema("2s")),
 )
 
 # Centralized schema for subcomponents

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-charger-example.yaml
+++ b/esp8266-charger-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-charging-converter-example.yaml
+++ b/esp8266-charging-converter-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-smart-shunt-example.yaml
+++ b/esp8266-smart-shunt-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-solar-charger-example.yaml
+++ b/esp8266-solar-charger-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/esp8266-triple-charger-example.yaml
+++ b/esp8266-triple-charger-example.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-fake-charger-vbcs-triple.yaml
+++ b/tests/esp8266-fake-charger-vbcs-triple.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-charger.yaml
+++ b/tests/esp8266-fake-charger.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-charging-converter.yaml
+++ b/tests/esp8266-fake-charging-converter.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0

--- a/tests/esp8266-fake-solar-charger.yaml
+++ b/tests/esp8266-fake-solar-charger.yaml
@@ -7,7 +7,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2026.2.0
   project:
     name: "syssi.esphome-votronic"
     version: 3.3.0


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.