### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/votronic/binary_sensor.py
+++ b/components/votronic/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_VOTRONIC_ID, VOTRONIC_COMPONENT_SCHEMA
 
@@ -50,58 +50,73 @@ CONFIG_SCHEMA = VOTRONIC_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
             icon="mdi:battery-charging",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
             icon="mdi:power-plug",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CHARGER_CHARGING): binary_sensor.binary_sensor_schema(
             icon="mdi:battery-charging",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CHARGER_DISCHARGING): binary_sensor.binary_sensor_schema(
             icon="mdi:power-plug",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CHARGER_CONTROLLER_ACTIVE): binary_sensor.binary_sensor_schema(
             icon="mdi:power",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CHARGER_CURRENT_REDUCTION): binary_sensor.binary_sensor_schema(
             icon="mdi:car-speed-limiter",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CHARGER_AES_ACTIVE): binary_sensor.binary_sensor_schema(
             icon="mdi:export",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_CHARGING
         ): binary_sensor.binary_sensor_schema(
             icon="mdi:battery-charging",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_DISCHARGING
         ): binary_sensor.binary_sensor_schema(
             icon="mdi:power-plug",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_CONTROLLER_ACTIVE
         ): binary_sensor.binary_sensor_schema(
             icon="mdi:power",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_CURRENT_REDUCTION
         ): binary_sensor.binary_sensor_schema(
             icon="mdi:car-speed-limiter",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_AES_ACTIVE
         ): binary_sensor.binary_sensor_schema(
             icon="mdi:export",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_PV_CONTROLLER_ACTIVE): binary_sensor.binary_sensor_schema(
             icon="mdi:power",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_PV_CURRENT_REDUCTION): binary_sensor.binary_sensor_schema(
             icon="mdi:car-speed-limiter",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_PV_AES_ACTIVE): binary_sensor.binary_sensor_schema(
             icon="mdi:export",
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )
@@ -112,6 +127,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/votronic_ble/binary_sensor.py
+++ b/components/votronic_ble/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_VOTRONIC_BLE_ID, VOTRONIC_BLE_SCHEMA
 
@@ -32,19 +32,29 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = VOTRONIC_BLE_SCHEMA.extend(
     {
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor, icon=ICON_CHARGING
+            binary_sensor.BinarySensor,
+            icon=ICON_CHARGING,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor, icon=ICON_DISCHARGING
+            binary_sensor.BinarySensor,
+            icon=ICON_DISCHARGING,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CONTROLLER_ACTIVE): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor, icon=ICON_CONTROLLER_ACTIVE
+            binary_sensor.BinarySensor,
+            icon=ICON_CONTROLLER_ACTIVE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_CURRENT_REDUCTION): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor, icon=ICON_CURRENT_REDUCTION
+            binary_sensor.BinarySensor,
+            icon=ICON_CURRENT_REDUCTION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_AES_ACTIVE): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor, icon=ICON_AES_ACTIVE
+            binary_sensor.BinarySensor,
+            icon=ICON_AES_ACTIVE,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )
@@ -55,6 +65,5 @@ async def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            await binary_sensor.register_binary_sensor(sens, conf)
+            sens = await binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.