### PR TITLE
Fix text_sensor_schema positional arg

### DIFF
--- a/components/votronic/text_sensor.py
+++ b/components/votronic/text_sensor.py
@@ -38,40 +38,34 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = VOTRONIC_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BATTERY_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:alert-circle-outline"
+            icon="mdi:alert-circle-outline"
         ),
         cv.Optional(CONF_CHARGER_MODE_SETTING): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:car-battery"
+            icon="mdi:car-battery"
         ),
         cv.Optional(CONF_CHARGER_CONTROLLER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:heart-pulse"
+            icon="mdi:heart-pulse"
         ),
         cv.Optional(CONF_CHARGER_BATTERY_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:alert-circle-outline"
+            icon="mdi:alert-circle-outline"
         ),
         cv.Optional(
             CONF_CHARGING_CONVERTER_BATTERY_STATUS
-        ): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:car-battery"
-        ),
+        ): text_sensor.text_sensor_schema(icon="mdi:car-battery"),
         cv.Optional(
             CONF_CHARGING_CONVERTER_CONTROLLER_STATUS
-        ): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:heart-pulse"
-        ),
+        ): text_sensor.text_sensor_schema(icon="mdi:heart-pulse"),
         cv.Optional(
             CONF_CHARGING_CONVERTER_MODE_SETTING
-        ): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:car-battery"
-        ),
+        ): text_sensor.text_sensor_schema(icon="mdi:car-battery"),
         cv.Optional(CONF_PV_MODE_SETTING): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:car-battery"
+            icon="mdi:car-battery"
         ),
         cv.Optional(CONF_PV_BATTERY_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:alert-circle-outline"
+            icon="mdi:alert-circle-outline"
         ),
         cv.Optional(CONF_PV_CONTROLLER_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon="mdi:heart-pulse"
+            icon="mdi:heart-pulse"
         ),
     }
 )

--- a/components/votronic_ble/text_sensor.py
+++ b/components/votronic_ble/text_sensor.py
@@ -22,11 +22,9 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = VOTRONIC_BLE_SCHEMA.extend(
     {
         cv.Optional(CONF_BATTERY_STATUS): text_sensor.text_sensor_schema(
-            class_=text_sensor.TextSensor,
             icon=ICON_BATTERY_STATUS,
         ),
         cv.Optional(CONF_PV_CONTROLLER_STATUS): text_sensor.text_sensor_schema(
-            class_=text_sensor.TextSensor,
             icon=ICON_PV_CONTROLLER_STATUS,
         ),
     }


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `votronic` and `votronic_ble` components (T1)

Follows the pattern established in `esphome-tianpower-bms`.