### PR TITLE
Explicitly declare ble_client as a component dependency

### DIFF
--- a/components/votronic_ble/__init__.py
+++ b/components/votronic_ble/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import CONF_ID, CONF_THROTTLE
 
 AUTO_LOAD = ["binary_sensor", "sensor", "text_sensor"]
 CODEOWNERS = ["@syssi"]
+DEPENDENCIES = ["ble_client"]
 MULTI_CONF = True
 
 CONF_VOTRONIC_BLE_ID = "votronic_ble_id"


### PR DESCRIPTION
## Summary

Add \`DEPENDENCIES = ["ble_client"]\` to \`__init__.py\` to explicitly declare the dependency on \`ble_client\`.

All components in ESPHome core that use \`BLE_CLIENT_SCHEMA\` declare this dependency (e.g. \`airthings_wave_base\`, \`bedjet\`, \`pvvx_mithermometer\`). This makes the requirement explicit and consistent with the upstream pattern.