### PR TITLE
Align code style with ESPHome core

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -38,21 +38,3 @@ ignore =
     D209,
     D400,
     D401,
-
-[isort]
-# https://github.com/timothycrosley/isort
-# https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_first_party = custom_components,tests
-forced_separate = tests
-combine_as_imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,15 +41,6 @@ repos:
         args: [--persistent=n, components]
         pass_filenames: false
         additional_dependencies: [esphome]
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: pytest
-        language: python
-        types: [python]
-        pass_filenames: false
-        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,13 @@
 # See https://pre-commit.com/hooks.html for more hooks
 # See https://github.com/rytilahti/python-miio/blob/master/.pre-commit-config.yaml
 repos:
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
     hooks:
-      - id: isort
+      - id: no-commit-to-branch
+        args: [--branch=main]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.5.5
@@ -15,13 +18,6 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.0
     hooks:
@@ -38,6 +34,22 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.3.4
+    hooks:
+      - id: pylint
+        args: [--persistent=n, components]
+        pass_filenames: false
+        additional_dependencies: [esphome]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: python
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: [pytest, esphome]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[tool.pylint.MAIN]
+py-version = "3.11"
+persistent = false
+
+[tool.pylint.REPORTS]
+score = false
+
+[tool.pylint."MESSAGES CONTROL"]
+# Mirrors ESPHome's pyproject.toml
+disable = [
+  "format",
+  "missing-docstring",
+  "fixme",
+  "unused-argument",
+  "global-statement",
+  "too-few-public-methods",
+  "too-many-lines",
+  "too-many-locals",
+  "too-many-ancestors",
+  "too-many-branches",
+  "too-many-statements",
+  "too-many-arguments",
+  "too-many-positional-arguments",
+  "too-many-return-statements",
+  "too-many-instance-attributes",
+  "duplicate-code",
+  "invalid-name",
+  "cyclic-import",
+  "redefined-builtin",
+  "undefined-loop-variable",
+  "useless-object-inheritance",
+  "stop-iteration-return",
+  "import-outside-toplevel",
+  # Broken
+  "unsupported-membership-test",
+  "unsubscriptable-object",
+]
+
+[tool.pylint.FORMAT]
+expected-line-ending-format = "LF"
+
+[tool.ruff]
+required-version = ">=0.5.0"
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle
+  "F",    # pyflakes/autoflake
+  "FURB", # refurb
+  "I",    # isort
+  "PERF", # performance
+  "PL",   # pylint
+  "SIM",  # flake8-simplify
+  "RET",  # flake8-ret
+  "UP",   # pyupgrade
+]
+
+ignore = [
+  "E501",    # line too long
+  "PLC0415", # `import` should be at the top-level of a file
+  "PLR0911", # Too many return statements
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments to function call
+  "PLR0915", # Too many statements
+  "PLW1641", # Object does not implement `__hash__` method
+  "PLR2004", # Magic value used in comparison
+  "PLW2901", # Outer variable overwritten by inner target
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["components"]
+combine-as-imports = true
+split-on-trailing-comma = false

--- a/votronic_display_link.md
+++ b/votronic_display_link.md
@@ -133,5 +133,3 @@ uart:
 * https://github.com/TheRealMoeder/vosodi
 * https://github.com/crathje/VotronicSRDuoDig
 * https://github.com/SirReal-surreal/SirReal-surreal/blob/main/2021_08_16_Votronic.json
-
-


### PR DESCRIPTION
## Summary

- Replace `setup.cfg` (flake8 + isort) with `pyproject.toml` and `.flake8`
- Migrate pylint config to `pyproject.toml`, mirroring ESPHome core settings
- Update ruff rules to match ESPHome core (`FURB`, `PERF`, `PL`, `SIM`, `RET`)
- Remove standalone `isort` and `black` hooks — replaced by `ruff` and `ruff-format`
- Add `pre-commit-hooks`: `no-commit-to-branch`, `end-of-file-fixer`, `trailing-whitespace`
- Add `pylint` pre-commit hook

## References

- ESPHome core: [pyproject.toml](https://github.com/esphome/esphome/blob/dev/pyproject.toml)
- Reference PR: syssi/esphome-daly-bms#86
