### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/votronic/votronic.cpp
+++ b/components/votronic/votronic.cpp
@@ -27,7 +27,7 @@ static const uint8_t VOTRONIC_FRAME_TYPE_CONTROL_CHARGING_CONVERTER2 = 0x4A;
 static const uint8_t VOTRONIC_FRAME_TYPE_CONTROL_BATTERY_COMPUTER = 0xEA;
 
 static const uint8_t BATTERY_STATUS_SIZE = 8;
-static const char *const BATTERY_STATUS[BATTERY_STATUS_SIZE] = {
+static constexpr const char *const BATTERY_STATUS[BATTERY_STATUS_SIZE] = {
     "I phase",         // 0000 0001
     "U1 phase",        // 0000 0010
     "U2 phase",        // 0000 0100
@@ -39,7 +39,7 @@ static const char *const BATTERY_STATUS[BATTERY_STATUS_SIZE] = {
 };
 
 static const uint8_t SOLAR_CHARGER_STATUS_SIZE = 8;
-static const char *const SOLAR_CHARGER_STATUS[SOLAR_CHARGER_STATUS_SIZE] = {
+static constexpr const char *const SOLAR_CHARGER_STATUS[SOLAR_CHARGER_STATUS_SIZE] = {
     "Unused (Bit 0)",  // 0000 0001
     "Unused (Bit 1)",  // 0000 0010
     "Unused (Bit 2)",  // 0000 0100
@@ -51,7 +51,7 @@ static const char *const SOLAR_CHARGER_STATUS[SOLAR_CHARGER_STATUS_SIZE] = {
 };
 
 static const uint8_t CHARGER_STATUS_SIZE = 8;
-static const char *const CHARGER_STATUS[CHARGER_STATUS_SIZE] = {
+static constexpr const char *const CHARGER_STATUS[CHARGER_STATUS_SIZE] = {
     "Unused (Bit 0)",                         // 0000 0001
     "Unused (Bit 1)",                         // 0000 0010
     "Charging Battery 1",                     // 0000 0100


### PR DESCRIPTION
## Summary

Replace `static const char *const` array declarations with `static constexpr const char *const` in `components/votronic/votronic.cpp` for the three status arrays (`BATTERY_STATUS`, `SOLAR_CHARGER_STATUS`, `CHARGER_STATUS`).

## Why

Using `static constexpr const char *const` for string arrays ensures the data is placed in the read-only segment (Flash) at compile time instead of occupying RAM at runtime. This is especially relevant on embedded targets like ESP8266/ESP32 where RAM is a scarce resource.

This also aligns with the style used in ESPHome core components such as `bme68x_bsec2.cpp`, keeping the codebase consistent with upstream conventions.

## Test plan

- [ ] Verify the component compiles without warnings or errors
- [ ] Confirm no functional behaviour changes