### PR TITLE
Bump clang-tidy from 18 to 22

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,224 @@
+---
+Checks: >-
+  *,
+  -abseil-*,
+  -altera-*,
+  -android-*,
+  -boost-*,
+  -bugprone-derived-method-shadowing-base-method,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-invalid-enum-default-initialization,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -bugprone-narrowing-conversions,
+  -bugprone-tagged-union-member-count,
+  -bugprone-signed-char-misuse,
+  -bugprone-switch-missing-default-case,
+  -cert-dcl50-cpp,
+  -cert-err33-c,
+  -cert-err58-cpp,
+  -cert-int09-c,
+  -cert-oop57-cpp,
+  -cert-str34-c,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-osx.*,
+  -clang-analyzer-security.ArrayBound,
+  -clang-diagnostic-delete-abstract-non-virtual-dtor,
+  -clang-diagnostic-delete-non-abstract-non-virtual-dtor,
+  -clang-diagnostic-deprecated-declarations,
+  -clang-diagnostic-ignored-optimization-argument,
+  -clang-diagnostic-missing-designated-field-initializers,
+  -clang-diagnostic-missing-field-initializers,
+  -clang-diagnostic-shadow-field,
+  -clang-diagnostic-unused-const-variable,
+  -clang-diagnostic-unused-parameter,
+  -clang-diagnostic-vla-cxx-extension,
+  -concurrency-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-missing-std-forward,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-rvalue-reference-param-not-moved,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-use-default-member-init,
+  -cppcoreguidelines-use-enum-class,
+  -cppcoreguidelines-virtual-class-destructor,
+  -fuchsia-default-arguments-calls,
+  -fuchsia-default-arguments-declarations,
+  -fuchsia-multiple-inheritance,
+  -fuchsia-overloaded-operator,
+  -fuchsia-statically-constructed-objects,
+  -google-build-using-namespace,
+  -google-explicit-constructor,
+  -google-readability-braces-around-statements,
+  -google-readability-casting,
+  -google-readability-namespace-comments,
+  -google-readability-todo,
+  -google-runtime-references,
+  -hicpp-*,
+  -llvm-else-after-return,
+  -llvm-header-guard,
+  -llvm-include-order,
+  -llvm-prefer-static-over-anonymous-namespace,
+  -llvm-qualified-auto,
+  -llvm-use-ranges,
+  -llvmlibc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-multiple-inheritance,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-override-with-different-visibility,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  -misc-use-internal-linkage,
+  -modernize-avoid-bind,
+  -modernize-avoid-variadic-functions,
+  -modernize-avoid-c-arrays,
+  -modernize-avoid-c-style-cast,
+  -modernize-concat-nested-namespaces,
+  -modernize-macro-to-enum,
+  -modernize-return-braced-init-list,
+  -modernize-type-traits,
+  -modernize-use-auto,
+  -modernize-use-constraints,
+  -modernize-use-default-member-init,
+  -modernize-use-designated-initializers,
+  -modernize-use-equals-default,
+  -modernize-use-integer-sign-comparison,
+  -modernize-use-nodiscard,
+  -modernize-use-nullptr,
+  -modernize-use-ranges,
+  -modernize-use-trailing-return-type,
+  -mpi-*,
+  -objc-*,
+  -performance-enum-size,
+  -portability-avoid-pragma-once,
+  -portability-template-virtual-member-function,
+  -readability-ambiguous-smartptr-reset-call,
+  -readability-avoid-nested-conditional-operator,
+  -readability-container-contains,
+  -readability-container-data-pointer,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
+  -readability-enum-initial-value,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-math-missing-parentheses,
+  -readability-named-parameter,
+  -readability-redundant-casting,
+  -readability-redundant-inline-specifier,
+  -readability-redundant-member-init,
+  -readability-redundant-parentheses,
+  -readability-redundant-string-init,
+  -readability-redundant-typename,
+  -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
+  -readability-use-std-min-max,
+  -readability-use-concise-preprocessor-directives,
+WarningsAsErrors: '*'
+FormatStyle:     google
+CheckOptions:
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-runtime-int.TypeSuffix
+    value:           '_t'
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '10'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           'esphome/core/helpers.h'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           2
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.GlobalConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.PrivateMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ProtectedMethodSuffix
+    value:           '_'
+  - key:             readability-identifier-naming.VirtualMethodCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.VirtualMethodSuffix
+    value:           ''
+  - key:             readability-qualified-auto.AddConstToQualified
+    value:           0
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           0
+  - key:             readability-identifier-length.MinimumLoopCounterNameLength
+    value:           0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -373,6 +373,21 @@ jobs:
           mkdir -p .temp
           pio run --list-targets -e esp32-idf-tidy
 
+      - name: Install clang-tidy
+        run: |
+          . venv/bin/activate
+          pip install clang-tidy -c requirements_dev.txt
+
+      - name: Install clang-tidy
+        run: |
+          . venv/bin/activate
+          pip install clang-tidy -c requirements_dev.txt
+
+      - name: Install clang-tidy
+        run: |
+          . venv/bin/activate
+          pip install clang-tidy -c requirements_dev.txt
+
       - name: Run clang-tidy
         run: |
           . venv/bin/activate

--- a/.yamllint
+++ b/.yamllint
@@ -7,6 +7,7 @@ yaml-files:
 
 ignore: |
   .clang-format
+  .clang-tidy
   .esphome/
   tests/.esphome/
 


### PR DESCRIPTION
## Summary

- ESPHome dev bumped clang-tidy from 18.1.8 to 22.1.0.1 ([esphome/esphome@53b682e](https://github.com/esphome/esphome/commit/53b682e48fce681685d0e19d62d0a52db0441043))
- The CI previously relied on `clang-tidy-18` being available as a system binary on the ubuntu-24.04 runner; `script/clang-tidy` now looks for version 22, which is not a system binary
- The venv cache never included clang-tidy (only `requirements.txt` + `requirements_test.txt` are installed, not `requirements_dev.txt`), so cache invalidation alone would not fix this

## Changes

- Add an explicit `pip install clang-tidy -c requirements_dev.txt` step before `script/clang-tidy`, mirroring the existing `clang-format` step
- Sync `.clang-tidy` with the updated upstream config from `esphome/esphome@dev`
- Exclude `.clang-tidy` from yamllint (it uses clang-tidy's YAML dialect with different formatting conventions)