### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/votronic/votronic.cpp
+++ b/components/votronic/votronic.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace votronic {
+namespace esphome::votronic {
 
 static const char *const TAG = "votronic";
 static const char *const TAG_INFO1 = "votronic.i1";
@@ -664,5 +663,4 @@ std::string Votronic::charger_status_bitmask_to_string_(const uint8_t mask) {
   return errors_list;
 }
 
-}  // namespace votronic
-}  // namespace esphome
+}  // namespace esphome::votronic

--- a/components/votronic/votronic.h
+++ b/components/votronic/votronic.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace votronic {
+namespace esphome::votronic {
 
 class Votronic : public uart::UARTDevice, public PollingComponent {
  public:
@@ -295,5 +294,4 @@ class Votronic : public uart::UARTDevice, public PollingComponent {
   }
 };
 
-}  // namespace votronic
-}  // namespace esphome
+}  // namespace esphome::votronic

--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace votronic_ble {
+namespace esphome::votronic_ble {
 
 static const char *const TAG = "votronic_ble";
 
@@ -329,5 +328,4 @@ std::string VotronicBle::solar_charger_status_bitmask_to_string_(const uint8_t m
   return format_unknown_hex(mask);
 }
 
-}  // namespace votronic_ble
-}  // namespace esphome
+}  // namespace esphome::votronic_ble

--- a/components/votronic_ble/votronic_ble.h
+++ b/components/votronic_ble/votronic_ble.h
@@ -12,8 +12,7 @@
 
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace votronic_ble {
+namespace esphome::votronic_ble {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -141,7 +140,6 @@ class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingCom
   std::string solar_charger_status_bitmask_to_string_(uint8_t mask);
 };
 
-}  // namespace votronic_ble
-}  // namespace esphome
+}  // namespace esphome::votronic_ble
 
 #endif


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.