### PR TITLE
Add C++ tests for votronic_ble

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -561,7 +561,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py votronic
+          script/cpp_unit_test.py votronic votronic_ble
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -109,13 +109,6 @@ void VotronicBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
   }
 }
 
-void VotronicBle::update() {
-  if (this->node_state != espbt::ClientState::ESTABLISHED) {
-    ESP_LOGW(TAG, "[%s] Not connected", this->parent_->address_str());
-    return;
-  }
-}
-
 void VotronicBle::on_votronic_ble_data(const uint8_t &handle, const std::vector<uint8_t> &data) {
   if (handle == this->char_solar_charger_handle_) {
     this->decode_solar_charger_data_(data);
@@ -134,6 +127,15 @@ void VotronicBle::on_votronic_ble_data(const uint8_t &handle, const std::vector<
 }
 
 #endif  // USE_ESP32
+
+void VotronicBle::update() {
+#ifdef USE_ESP32
+  if (this->node_state != espbt::ClientState::ESTABLISHED) {
+    ESP_LOGW(TAG, "[%s] Not connected", this->parent_->address_str());
+    return;
+  }
+#endif
+}
 
 void VotronicBle::decode_battery_computer_data_(const std::vector<uint8_t> &data) {
   if (data.size() != 20) {

--- a/components/votronic_ble/votronic_ble.cpp
+++ b/components/votronic_ble/votronic_ble.cpp
@@ -6,6 +6,8 @@ namespace esphome::votronic_ble {
 
 static const char *const TAG = "votronic_ble";
 
+#ifdef USE_ESP32
+
 void VotronicBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                       esp_ble_gattc_cb_param_t *param) {
   switch (event) {
@@ -131,6 +133,8 @@ void VotronicBle::on_votronic_ble_data(const uint8_t &handle, const std::vector<
            format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 }
 
+#endif  // USE_ESP32
+
 void VotronicBle::decode_battery_computer_data_(const std::vector<uint8_t> &data) {
   if (data.size() != 20) {
     ESP_LOGW(TAG, "Invalid frame size: %zu", data.size());
@@ -221,6 +225,7 @@ void VotronicBle::decode_solar_charger_data_(const std::vector<uint8_t> &data) {
 
 void VotronicBle::dump_config() {
   ESP_LOGCONFIG(TAG, "VotronicBle:");
+#ifdef USE_ESP32
   ESP_LOGCONFIG(TAG, "  MAC address                         : %s", this->parent_->address_str());
   char service_monitoring_uuid_str[esp32_ble::UUID_STR_LEN];
   char char_battery_computer_uuid_str[esp32_ble::UUID_STR_LEN];
@@ -231,6 +236,7 @@ void VotronicBle::dump_config() {
                 this->char_battery_computer_uuid_.to_str(char_battery_computer_uuid_str));
   ESP_LOGCONFIG(TAG, "  Solar Charger Characteristic UUID   : %s",
                 this->char_solar_charger_uuid_.to_str(char_solar_charger_uuid_str));
+#endif
 
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);

--- a/components/votronic_ble/votronic_ble.h
+++ b/components/votronic_ble/votronic_ble.h
@@ -2,24 +2,32 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/components/ble_client/ble_client.h"
-#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 #ifdef USE_ESP32
-
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include <esp_gattc_api.h>
+#endif
 
 namespace esphome::votronic_ble {
 
+#ifdef USE_ESP32
 namespace espbt = esphome::esp32_ble_tracker;
+#endif
 
-class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingComponent {
+class VotronicBle :
+#ifdef USE_ESP32
+    public esphome::ble_client::BLEClientNode,
+#endif
+    public PollingComponent {
  public:
+#ifdef USE_ESP32
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
+#endif
   void dump_config() override;
   void update() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -80,7 +88,9 @@ class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingCom
     pv_controller_status_text_sensor_ = pv_controller_status_text_sensor;
   }
 
+#ifdef USE_ESP32
   void on_votronic_ble_data(const uint8_t &handle, const std::vector<uint8_t> &data);
+#endif
   void set_throttle(uint32_t throttle) { this->throttle_ = throttle; }
 
  protected:
@@ -108,11 +118,9 @@ class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingCom
   text_sensor::TextSensor *battery_status_text_sensor_{nullptr};
   text_sensor::TextSensor *pv_controller_status_text_sensor_{nullptr};
 
+#ifdef USE_ESP32
   uint16_t char_battery_computer_handle_{0x22};
   uint16_t char_solar_charger_handle_{0x25};
-  uint32_t last_battery_computer_data_{0};
-  uint32_t last_solar_charger_data_{0};
-  uint32_t throttle_;
 
   esp32_ble_tracker::ESPBTUUID service_bond_uuid_ =
       esp32_ble_tracker::ESPBTUUID::from_raw("70521e61-022d-f899-d046-4885a76acbd0");
@@ -130,6 +138,11 @@ class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingCom
       esp32_ble_tracker::ESPBTUUID::from_raw("ac12f485-cab7-4e0a-aac5-3585918852f6");
   esp32_ble_tracker::ESPBTUUID char_bulk_data_uuid_ =
       esp32_ble_tracker::ESPBTUUID::from_raw("b8a37ffe-c57b-4007-b3c1-ca05a6b7f0c6");
+#endif
+
+  uint32_t last_battery_computer_data_{0};
+  uint32_t last_solar_charger_data_{0};
+  uint32_t throttle_{0};
 
   void decode_solar_charger_data_(const std::vector<uint8_t> &data);
   void decode_battery_computer_data_(const std::vector<uint8_t> &data);
@@ -141,5 +154,3 @@ class VotronicBle : public esphome::ble_client::BLEClientNode, public PollingCom
 };
 
 }  // namespace esphome::votronic_ble
-
-#endif

--- a/tests/components/votronic_ble/common.h
+++ b/tests/components/votronic_ble/common.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "esphome/components/votronic_ble/votronic_ble.h"
+
+namespace esphome::votronic_ble::testing {
+
+class TestableVotronicBle : public VotronicBle {
+ public:
+  TestableVotronicBle() { set_throttle(0); }
+  void update() override {}
+  using VotronicBle::decode_solar_charger_data_;
+  using VotronicBle::decode_battery_computer_data_;
+  using VotronicBle::battery_status_bitmask_to_string_;
+  using VotronicBle::solar_charger_status_bitmask_to_string_;
+};
+
+}  // namespace esphome::votronic_ble::testing

--- a/tests/components/votronic_ble/frames.h
+++ b/tests/components/votronic_ble/frames.h
@@ -1,0 +1,104 @@
+#pragma once
+#include <vector>
+
+namespace esphome::votronic_ble::testing {
+
+// Solar charger frames (19 bytes each)
+// Byte layout:
+//   0-1:  battery_voltage * 100  (LE)
+//   2-3:  pv_voltage * 100       (LE)
+//   4-5:  pv_current * 10        (LE)
+//   6-7:  unknown
+//   8:    battery_status_bitmask
+//   9-11: unknown
+//   12:   pv_controller_status_bitmask
+//   13-14: charged_capacity      (LE)
+//   15-16: charged_energy / 10   (LE)
+//   17-18: pv_power * 10         (LE)
+
+// Active charging: bat=13.56V, pv=22.40V, I=5.0A, P=112.0W,
+//   battery_status=U1 phase (0x02), controller=Active (0x08),
+//   charged_capacity=100Ah, charged_energy=5000Wh
+static const std::vector<uint8_t> SOLAR_CHARGER_FRAME_ACTIVE = {
+    0x4C, 0x05,        // battery_voltage: 1356 * 0.01 = 13.56 V
+    0xC0, 0x08,        // pv_voltage: 2240 * 0.01 = 22.40 V
+    0x32, 0x00,        // pv_current: 50 * 0.1 = 5.0 A
+    0x00, 0x00,        // unknown
+    0x02,              // battery_status: U1 phase
+    0x00, 0x00, 0x00,  // unknown
+    0x08,              // pv_controller_status: Active (bit 3)
+    0x64, 0x00,        // charged_capacity: 100 Ah
+    0xF4, 0x01,        // charged_energy: 500 * 10 = 5000 Wh
+    0x60, 0x04,        // pv_power: 1120 * 0.1 = 112.0 W
+};
+
+// AES active: bat=12.60V, pv=12.55V, I=0.3A, P=0.3W,
+//   battery_status=Standby (0x00), controller=AES active (0x20)
+static const std::vector<uint8_t> SOLAR_CHARGER_FRAME_AES = {
+    0xEC, 0x04,        // battery_voltage: 1260 * 0.01 = 12.60 V
+    0xE7, 0x04,        // pv_voltage: 1255 * 0.01 = 12.55 V
+    0x03, 0x00,        // pv_current: 3 * 0.1 = 0.3 A
+    0x00, 0x00,        // unknown
+    0x00,              // battery_status: Standby
+    0x00, 0x00, 0x00,  // unknown
+    0x20,              // pv_controller_status: AES active (bit 5)
+    0x32, 0x00,        // charged_capacity: 50 Ah
+    0x0A, 0x00,        // charged_energy: 10 * 10 = 100 Wh
+    0x03, 0x00,        // pv_power: 3 * 0.1 = 0.3 W
+};
+
+// Reduced output: pv_controller_status=Reduced (0x10)
+static const std::vector<uint8_t> SOLAR_CHARGER_FRAME_REDUCED = {
+    0x58, 0x05,        // battery_voltage: 1368 * 0.01 = 13.68 V
+    0x48, 0x0B,        // pv_voltage: 2888 * 0.01 = 28.88 V
+    0x14, 0x00,        // pv_current: 20 * 0.1 = 2.0 A
+    0x00, 0x00,        // unknown
+    0x04,              // battery_status: U2 phase (bit 2)
+    0x00, 0x00, 0x00,  // unknown
+    0x10,              // pv_controller_status: Reduced (bit 4)
+    0xC8, 0x00,        // charged_capacity: 200 Ah
+    0x32, 0x00,        // charged_energy: 50 * 10 = 500 Wh
+    0x14, 0x00,        // pv_power: 20 * 0.1 = 2.0 W
+};
+
+// Battery computer frames (20 bytes each)
+// Byte layout:
+//   0-1:  battery_voltage * 100           (LE)
+//   2-3:  secondary_battery_voltage * 100 (LE)
+//   4-5:  battery_capacity_remaining      (LE)
+//   6-7:  unknown
+//   8:    state_of_charge
+//   9:    unknown
+//   10-12: current * 1000                 (24-bit signed LE)
+//   13-14: battery_nominal_capacity * 10  (LE)
+//   15-19: unknown
+
+// Charging: bat=13.50V, sec=13.20V, cap=150Ah, soc=75%, I=+5.000A,
+//   P=67.50W, nominal=200Ah
+static const std::vector<uint8_t> BATTERY_COMPUTER_FRAME_CHARGING = {
+    0x46, 0x05,                    // battery_voltage: 1350 * 0.01 = 13.50 V
+    0x28, 0x05,                    // secondary_voltage: 1320 * 0.01 = 13.20 V
+    0x96, 0x00,                    // capacity_remaining: 150 Ah
+    0x00, 0x00,                    // unknown
+    0x4B,                          // state_of_charge: 75 %
+    0x00,                          // unknown
+    0x88, 0x13, 0x00,              // current: 5000 * 0.001 = 5.000 A
+    0xD0, 0x07,                    // nominal_capacity: 2000 * 0.1 = 200.0 Ah
+    0x00, 0x00, 0x00, 0x00, 0x00,  // unknown
+};
+
+// Discharging: bat=12.80V, sec=12.70V, cap=120Ah, soc=60%, I=-2.500A,
+//   P=-32.0W, nominal=200Ah
+static const std::vector<uint8_t> BATTERY_COMPUTER_FRAME_DISCHARGING = {
+    0x00, 0x05,                    // battery_voltage: 1280 * 0.01 = 12.80 V
+    0xF6, 0x04,                    // secondary_voltage: 1270 * 0.01 = 12.70 V
+    0x78, 0x00,                    // capacity_remaining: 120 Ah
+    0x00, 0x00,                    // unknown
+    0x3C,                          // state_of_charge: 60 %
+    0x00,                          // unknown
+    0x3C, 0xF6, 0xFF,              // current: 0xFFF63C -> -2500 * 0.001 = -2.500 A
+    0xD0, 0x07,                    // nominal_capacity: 2000 * 0.1 = 200.0 Ah
+    0x00, 0x00, 0x00, 0x00, 0x00,  // unknown
+};
+
+}  // namespace esphome::votronic_ble::testing

--- a/tests/components/votronic_ble/test.host.yaml
+++ b/tests/components/votronic_ble/test.host.yaml
@@ -1,0 +1,3 @@
+votronic_ble:
+  id: test_votronic_ble
+  update_interval: 2s

--- a/tests/components/votronic_ble/votronic_ble_test.cpp
+++ b/tests/components/votronic_ble/votronic_ble_test.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+#include "common.h"
+#include "frames.h"
+
+namespace esphome::votronic_ble::testing {
+
+// Solar charger
+
+TEST(VotronicBleSolarTest, BatteryVoltage) {
+  TestableVotronicBle ble;
+  sensor::Sensor battery_voltage;
+  ble.set_battery_voltage_sensor(&battery_voltage);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+  EXPECT_NEAR(battery_voltage.state, 13.56f, 0.01f);
+}
+
+TEST(VotronicBleSolarTest, PvVoltageCurrentPower) {
+  TestableVotronicBle ble;
+  sensor::Sensor pv_voltage, pv_current, pv_power;
+  ble.set_pv_voltage_sensor(&pv_voltage);
+  ble.set_pv_current_sensor(&pv_current);
+  ble.set_pv_power_sensor(&pv_power);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+  EXPECT_NEAR(pv_voltage.state, 22.40f, 0.01f);
+  EXPECT_NEAR(pv_current.state, 5.0f, 0.01f);
+  EXPECT_NEAR(pv_power.state, 112.0f, 0.1f);
+}
+
+TEST(VotronicBleSolarTest, ChargedCapacityAndEnergy) {
+  TestableVotronicBle ble;
+  sensor::Sensor charged_capacity, charged_energy;
+  ble.set_charged_capacity_sensor(&charged_capacity);
+  ble.set_charged_energy_sensor(&charged_energy);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+  EXPECT_FLOAT_EQ(charged_capacity.state, 100.0f);
+  EXPECT_FLOAT_EQ(charged_energy.state, 5000.0f);
+}
+
+TEST(VotronicBleSolarTest, BatteryStatusU1Phase) {
+  TestableVotronicBle ble;
+  sensor::Sensor bitmask;
+  text_sensor::TextSensor status_text;
+  ble.set_battery_status_bitmask_sensor(&bitmask);
+  ble.set_battery_status_text_sensor(&status_text);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+  EXPECT_FLOAT_EQ(bitmask.state, 2.0f);
+  EXPECT_EQ(status_text.state, "U1 phase");
+}
+
+TEST(VotronicBleSolarTest, PvControllerActive) {
+  TestableVotronicBle ble;
+  sensor::Sensor pv_bitmask;
+  text_sensor::TextSensor pv_status;
+  binary_sensor::BinarySensor controller_active, current_reduction, aes_active;
+  ble.set_pv_controller_status_bitmask_sensor(&pv_bitmask);
+  ble.set_pv_controller_status_text_sensor(&pv_status);
+  ble.set_controller_active_binary_sensor(&controller_active);
+  ble.set_current_reduction_binary_sensor(&current_reduction);
+  ble.set_aes_active_binary_sensor(&aes_active);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+  EXPECT_FLOAT_EQ(pv_bitmask.state, 8.0f);
+  EXPECT_EQ(pv_status.state, "Active");
+  EXPECT_TRUE(controller_active.state);
+  EXPECT_FALSE(current_reduction.state);
+  EXPECT_FALSE(aes_active.state);
+}
+
+TEST(VotronicBleSolarTest, PvControllerAesActive) {
+  TestableVotronicBle ble;
+  text_sensor::TextSensor pv_status, battery_status;
+  binary_sensor::BinarySensor controller_active, current_reduction, aes_active;
+  ble.set_pv_controller_status_text_sensor(&pv_status);
+  ble.set_battery_status_text_sensor(&battery_status);
+  ble.set_controller_active_binary_sensor(&controller_active);
+  ble.set_current_reduction_binary_sensor(&current_reduction);
+  ble.set_aes_active_binary_sensor(&aes_active);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_AES);
+  EXPECT_EQ(pv_status.state, "AES active");
+  EXPECT_EQ(battery_status.state, "Standby");
+  EXPECT_FALSE(controller_active.state);
+  EXPECT_FALSE(current_reduction.state);
+  EXPECT_TRUE(aes_active.state);
+}
+
+TEST(VotronicBleSolarTest, PvControllerReduced) {
+  TestableVotronicBle ble;
+  text_sensor::TextSensor pv_status, battery_status;
+  binary_sensor::BinarySensor controller_active, current_reduction;
+  ble.set_pv_controller_status_text_sensor(&pv_status);
+  ble.set_battery_status_text_sensor(&battery_status);
+  ble.set_controller_active_binary_sensor(&controller_active);
+  ble.set_current_reduction_binary_sensor(&current_reduction);
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_REDUCED);
+  EXPECT_EQ(pv_status.state, "Reduced");
+  EXPECT_EQ(battery_status.state, "U2 phase");
+  EXPECT_FALSE(controller_active.state);
+  EXPECT_TRUE(current_reduction.state);
+}
+
+TEST(VotronicBleSolarTest, InvalidFrameSizeIgnored) {
+  TestableVotronicBle ble;
+  sensor::Sensor pv_voltage;
+  pv_voltage.state = -1.0f;
+  ble.set_pv_voltage_sensor(&pv_voltage);
+  ble.decode_solar_charger_data_({0xAA, 0xBB, 0xCC});
+  EXPECT_FLOAT_EQ(pv_voltage.state, -1.0f);
+}
+
+TEST(VotronicBleSolarTest, NullSensorsDoNotCrash) {
+  TestableVotronicBle ble;
+  ble.decode_solar_charger_data_(SOLAR_CHARGER_FRAME_ACTIVE);
+}
+
+// Battery computer
+
+TEST(VotronicBleBatteryComputerTest, ChargingVoltagesAndCapacity) {
+  TestableVotronicBle ble;
+  sensor::Sensor battery_voltage, secondary_voltage, capacity_remaining, soc, nominal_capacity;
+  ble.set_battery_voltage_sensor(&battery_voltage);
+  ble.set_secondary_battery_voltage_sensor(&secondary_voltage);
+  ble.set_battery_capacity_remaining_sensor(&capacity_remaining);
+  ble.set_state_of_charge_sensor(&soc);
+  ble.set_battery_nominal_capacity_sensor(&nominal_capacity);
+  ble.decode_battery_computer_data_(BATTERY_COMPUTER_FRAME_CHARGING);
+  EXPECT_NEAR(battery_voltage.state, 13.50f, 0.01f);
+  EXPECT_NEAR(secondary_voltage.state, 13.20f, 0.01f);
+  EXPECT_FLOAT_EQ(capacity_remaining.state, 150.0f);
+  EXPECT_FLOAT_EQ(soc.state, 75.0f);
+  EXPECT_NEAR(nominal_capacity.state, 200.0f, 0.1f);
+}
+
+TEST(VotronicBleBatteryComputerTest, ChargingCurrentPowerState) {
+  TestableVotronicBle ble;
+  sensor::Sensor battery_voltage, current, power;
+  binary_sensor::BinarySensor charging, discharging;
+  ble.set_battery_voltage_sensor(&battery_voltage);
+  ble.set_current_sensor(&current);
+  ble.set_power_sensor(&power);
+  ble.set_charging_binary_sensor(&charging);
+  ble.set_discharging_binary_sensor(&discharging);
+  ble.decode_battery_computer_data_(BATTERY_COMPUTER_FRAME_CHARGING);
+  EXPECT_NEAR(battery_voltage.state, 13.50f, 0.01f);
+  EXPECT_NEAR(current.state, 5.000f, 0.001f);
+  EXPECT_NEAR(power.state, 13.50f * 5.000f, 0.1f);
+  EXPECT_TRUE(charging.state);
+  EXPECT_FALSE(discharging.state);
+}
+
+TEST(VotronicBleBatteryComputerTest, DischargingCurrentState) {
+  TestableVotronicBle ble;
+  sensor::Sensor current;
+  binary_sensor::BinarySensor charging, discharging;
+  ble.set_current_sensor(&current);
+  ble.set_charging_binary_sensor(&charging);
+  ble.set_discharging_binary_sensor(&discharging);
+  ble.decode_battery_computer_data_(BATTERY_COMPUTER_FRAME_DISCHARGING);
+  EXPECT_NEAR(current.state, -2.500f, 0.001f);
+  EXPECT_FALSE(charging.state);
+  EXPECT_TRUE(discharging.state);
+}
+
+TEST(VotronicBleBatteryComputerTest, InvalidFrameSizeIgnored) {
+  TestableVotronicBle ble;
+  sensor::Sensor battery_voltage;
+  battery_voltage.state = -1.0f;
+  ble.set_battery_voltage_sensor(&battery_voltage);
+  ble.decode_battery_computer_data_({0xAA, 0xBB});
+  EXPECT_FLOAT_EQ(battery_voltage.state, -1.0f);
+}
+
+TEST(VotronicBleBatteryComputerTest, NullSensorsDoNotCrash) {
+  TestableVotronicBle ble;
+  ble.decode_battery_computer_data_(BATTERY_COMPUTER_FRAME_CHARGING);
+}
+
+// String converters
+
+TEST(VotronicBleBitmaskTest, BatteryStatusAllValues) {
+  TestableVotronicBle ble;
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x00), "Standby");
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x01), "I phase");
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x02), "U1 phase");
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x04), "U2 phase");
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x08), "U3 phase");
+}
+
+TEST(VotronicBleBitmaskTest, SolarChargerStatusAllValues) {
+  TestableVotronicBle ble;
+  EXPECT_EQ(ble.solar_charger_status_bitmask_to_string_(0x00), "Standby");
+  EXPECT_EQ(ble.solar_charger_status_bitmask_to_string_(0x08), "Active");
+  EXPECT_EQ(ble.solar_charger_status_bitmask_to_string_(0x10), "Reduced");
+  EXPECT_EQ(ble.solar_charger_status_bitmask_to_string_(0x20), "AES active");
+}
+
+TEST(VotronicBleBitmaskTest, UnknownBitmaskFormatted) {
+  TestableVotronicBle ble;
+  EXPECT_EQ(ble.battery_status_bitmask_to_string_(0x40), "Unknown (0x40)");
+  EXPECT_EQ(ble.solar_charger_status_bitmask_to_string_(0x01), "Unknown (0x01)");
+}
+
+}  // namespace esphome::votronic_ble::testing


### PR DESCRIPTION
## Summary

- Refactor `votronic_ble.h`/`.cpp` to guard BLE includes and inheritance with `#ifdef USE_ESP32`, matching the pattern already used by `treadmill_f15`
- Add `tests/components/votronic_ble/` with 18 unit tests for the decode paths

## Test coverage

- `decode_solar_charger_data_`: voltage, PV current/power, charged capacity/energy, battery status bitmask (Standby/U1/U2/U3 phase), PV controller status (Active/Reduced/AES active), binary sensors, invalid frame rejection, null sensor safety
- `decode_battery_computer_data_`: voltages, capacity remaining, SoC, charging/discharging current with sign, power, nominal capacity, invalid frame rejection, null sensor safety
- `battery_status_bitmask_to_string_` and `solar_charger_status_bitmask_to_string_`: all known values plus unknown fallback

## Test plan

- [ ] `esphome compile tests/components/votronic_ble/test.host.yaml`
- [ ] Run `gtest` binary produced by the host build